### PR TITLE
Enhancement (config): Change `UDP_FORWARD_ADDR` default value to match daemon's default IP:PORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Run `source-udp-forwarder -help` to see command line usage:
 | Environment variable | Description |
 |---|---|
 | `UDP_LISTEN_ADDR`  | `<IP>:<PORT>` to listen on for incoming packets. Default value: `:26999` |
-| `UDP_FORWARD_ADDR`  | `<IP>:<PORT>` or `<HOSTNAME>:<PORT>` to which incoming packets will be forwarded. Default value: `1.2.3.4:1013` |
+| `UDP_FORWARD_ADDR`  | `<IP>:<PORT>` or `<HOSTNAME>:<PORT>` to which incoming packets will be forwarded. Default value: `127.0.0.1:27500` |
 | `FORWARD_PROXY_KEY`  | The [`PROXY_KEY`](https://github.com/startersclan/hlstatsx-community-edition/blob/v1.6.19/scripts/hlstats.pl#L1780) secret defined in the HLStatsX:CE Web Admin Panel. Default value: `XXXXX` |
 | `FORWARD_GAMESERVER_IP`  | IP that the sent packet should include. Default value: `127.0.0.1` |
 | `FORWARD_GAMESERVER_PORT`  | Port that the sent packet should include. Default value: `27015` |

--- a/cmd/source-udp-forwarder/main.go
+++ b/cmd/source-udp-forwarder/main.go
@@ -37,7 +37,7 @@ func run() error {
 
 	var (
 		listenAddress  = flag.String("udp.listen-address", getEnv("UDP_LISTEN_ADDR", ":26999"), "<IP>:<Port> to listen on for incoming packets.")
-		forwardAddress = flag.String("udp.forward-address", getEnv("UDP_FORWARD_ADDR", "1.2.3.4:1013"), "<IP>:<Port> to which incoming packets will be forwarded.")
+		forwardAddress = flag.String("udp.forward-address", getEnv("UDP_FORWARD_ADDR", "127.0.0.1:27500"), "<IP>:<Port> of the daemon to which incoming packets will be forwarded.")
 
 		proxyKey = flag.String("forward.proxy-key", getEnv("FORWARD_PROXY_KEY", "XXXXX"), "The PROXY_KEY secret defined in HLStatsX:CE settings.")
 		srcIp    = flag.String("forward.gameserver-ip", getEnv("FORWARD_GAMESERVER_IP", "127.0.0.1"), "IP that the sent packet should include.")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,18 +4,14 @@ services:
     image: alpine:3.15
     environment:
       - UDP_LISTEN_ADDR=:26999
-      - UDP_FORWARD_ADDR=0.0.0.0:27500
+      - UDP_FORWARD_ADDR=127.0.0.1:27500
       - FORWARD_PROXY_KEY=XXXXX
       - FORWARD_GAMESERVER_IP=127.0.0.1
       - FORWARD_GAMESERVER_PORT=27015
       - LOG_LEVEL=DEBUG
-    # No need to publish ports, since we're using host networking. If you prefer container networking, comment out network_mode, and uncomment this.
-    # ports:
-    #   - target: 26999
-    #     published: 26999
-    #     protocol: udp
-    #     mode: host
-    network_mode: host
+      - LOG_FORMAT=txt
+    ports:
+      - 26999:26999/udp
     volumes:
       - ${OUTBIN?:err}:/${BIN?:err}
     entrypoint: /${BIN?:err}


### PR DESCRIPTION
The gameserver may log its rcon password (e.g. `hlds`) and the default `UDP_FORWARD_ADDR` may cause rcon password to go to the internet. A more expected and secure value of `UDP_FORWARD_ADDR` is now `127.0.0.1:27500`, which is actually the daemon's default listening IP:PORT.
