### PR TITLE
Fix (ci): Push `:latest` tag on tagged release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       env:
         DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
       run: |
-        make buildx-image "REGISTRY_USER=$DOCKERHUB_REGISTRY_USER" "BUILDX_PUSH=${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}"
+        make buildx-image "REGISTRY_USER=$DOCKERHUB_REGISTRY_USER" "BUILDX_TAG_LATEST={{ startsWith(github.ref, 'refs/tags/') }}" "BUILDX_PUSH=${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}"
 
   update-draft-release:
     needs: [build,test,docker]


### PR DESCRIPTION
Fixes bug in #14, resulting in `:latest` not being tagged on `v0.1.0`
